### PR TITLE
feat: use `$EDITOR` if set & non-empty, fallback to `vim -O`otherwise

### DIFF
--- a/cmdk.sh
+++ b/cmdk.sh
@@ -76,6 +76,6 @@ function cmdk() {
     done
 
     if [ "${#text_files[@]}" -gt 0 ]; then
-        vim -O "${text_files[@]}"
+        ${EDITOR:-vim -O} "${text_files[@]}"
     fi
 }


### PR DESCRIPTION
This allows users to set Sublime Text or VSCode as their preferred editor.