### PR TITLE
Fix bug with IFS getting incorrectly set to newline

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,9 @@ This is ⌘-k for the terminal: access anything on your filesystem, from anywher
 When you press enter, the type of selected files are identified and...
 
 - Directories get `cd`d to
-- Text files get opened in `vim`
+- Text files get opened in the command of your [`$EDITOR` variable](https://bash.cyberciti.biz/guide/$EDITOR_variable) (or `vim -O` if it's unset)
 - Images and PDFs get opened in the Preview app
 - `.key` files get opened in Keynote
-- 
 
 _I'm extremely grateful to [fzf](https://github.com/junegunn/fzf); this project wouldn't be possible without it. I'd been fed up with terminal navigation for a decade, and fzf was the missing piece needed to make cmdk possible._
 

--- a/cmdk.sh
+++ b/cmdk.sh
@@ -9,23 +9,26 @@ function cmdk() {
         cmdk_dirpath="${CMDK_DIRPATH}"
     fi
 
-    # EXPLANATION:
-    # -m allows multiple selections
-    # --ansi tells fzf to parse the ANSI color codes that we're generating with fd
-    # --scheme=path optimizes for path-based input
-    # --with-nth allows us to use the custom sorting mechanism
-    IFS=$'\n' output_paths=( 
-        $(FZF_DEFAULT_COMMAND="sh ${cmdk_dirpath}/list-files.sh ${1}" fzf \
+    output_paths=()
+
+    while IFS="" read -r line; do  # IFS="" -> no splitting (we may have paths with spaces)
+        output_paths+=("${line}")
+    done < <(
+        # EXPLANATION:
+        # -m allows multiple selections
+        # --ansi tells fzf to parse the ANSI color codes that we're generating with fd
+        # --scheme=path optimizes for path-based input
+        # --with-nth allows us to use the custom sorting mechanism
+        FZF_DEFAULT_COMMAND="sh ${cmdk_dirpath}/list-files.sh ${1}" fzf \
             -m \
             --ansi \
             --bind='change:top' \
             --scheme=path \
             --preview="sh ${cmdk_dirpath}/preview.sh {}"
-        )
+        if [ "${?}" -ne 0 ]; then
+            return
+        fi
     )
-    if [ "${?}" -ne 0 ]; then
-        return
-    fi
 
     dirs=()
     text_files=()
@@ -70,12 +73,13 @@ function cmdk() {
         echo "Error: Cannot cd to more than one directory at a time" >&2
         return 1
     fi
+    
 
     for open_target_filepath in "${open_targets[@]}"; do
         open "${open_target_filepath}"
     done
 
     if [ "${#text_files[@]}" -gt 0 ]; then
-        vim -O "${text_files[@]}"
+        ${EDITOR:-vim -O} "${text_files[@]}"
     fi
 }

--- a/cmdk.sh
+++ b/cmdk.sh
@@ -80,6 +80,6 @@ function cmdk() {
     done
 
     if [ "${#text_files[@]}" -gt 0 ]; then
-        ${EDITOR:-vim -O} "${text_files[@]}"
+        vim -O "${text_files[@]}"
     fi
 }


### PR DESCRIPTION
[spacelatte](https://github.com/spacelatte) had a great idea in #8 to use the `$EDITOR` variable instead of always using Vim. In testing his change, I realized that I'd left a bug `cmdk.sh` that made his fix (which should have worked) not work. This PR fixes that bug.