### PR TITLE
Fix variable name mismatch in shell wrappers

### DIFF
--- a/cmdk.fish
+++ b/cmdk.fish
@@ -9,7 +9,7 @@ function cmdk
         set cmdk_dirpath "$CMDK_DIRPATH"
     end
 
-    set core_response (bash "$CMDK_DIRPATH/cmdk-core.sh" $argv[1])
+    set core_response (bash "$cmdk_dirpath/cmdk-core.sh" $argv[1])
     if test $status -ne 0
         return 1
     end

--- a/cmdk.sh
+++ b/cmdk.sh
@@ -9,7 +9,7 @@ function cmdk() {
         cmdk_dirpath="${CMDK_DIRPATH}"
     fi
 
-    if ! core_response="$(bash "${CMDK_DIRPATH}/cmdk-core.sh" ${1})"; then
+    if ! core_response="$(bash "${cmdk_dirpath}/cmdk-core.sh" ${1})"; then
         return 1
     fi
 


### PR DESCRIPTION
## Summary
- Fixed variable name mismatch in both `cmdk.fish` and `cmdk.sh`
- Both files were incorrectly using `$CMDK_DIRPATH` instead of the local `$cmdk_dirpath` variable

## Problem
When the `CMDK_DIRPATH` environment variable is not set, the script should default to using `~/.cmdk`. However, due to the variable name mismatch, the path was becoming empty, resulting in the error:
```
bash: /cmdk-core.sh: No such file or directory
```

## Solution
Changed line 12 in both wrapper files to use the correctly set local variable `$cmdk_dirpath` instead of the environment variable `$CMDK_DIRPATH`.

## Test plan
- [x] Test in fish shell with `source ~/.cmdk/cmdk.fish && cmdk`
- [ ] Test in bash shell with `source ~/.cmdk/cmdk.sh && cmdk`
- [ ] Test in zsh shell with `source ~/.cmdk/cmdk.sh && cmdk`
- [ ] Test with `CMDK_DIRPATH` environment variable set
- [ ] Test without `CMDK_DIRPATH` environment variable set

🤖 Generated with [Claude Code](https://claude.ai/code)