### PR TITLE
Fix bash syntax error in process substitution

### DIFF
--- a/cmdk-core.sh
+++ b/cmdk-core.sh
@@ -11,24 +11,25 @@ script_dirpath="$(cd "$(dirname "${0}")" && pwd)"
 
 output_paths=()
 
+# EXPLANATION:
+# -m allows multiple selections
+# --ansi tells fzf to parse the ANSI color codes that we're generating with fd
+# --scheme=path optimizes for path-based input
+# --with-nth allows us to use the custom sorting mechanism
+fzf_output=$(FZF_DEFAULT_COMMAND="sh ${script_dirpath}/list-files.sh ${1:-}" fzf \
+    -m \
+    --ansi \
+    --bind='change:top' \
+    --scheme=path \
+    --preview="sh ${script_dirpath}/preview.sh {}")
+
+if [ "${?}" -ne 0 ]; then
+    exit 1
+fi
+
 while IFS="" read -r line; do  # IFS="" -> no splitting (we may have paths with spaces)
     output_paths+=("${line}")
-done < <(
-    # EXPLANATION:
-    # -m allows multiple selections
-    # --ansi tells fzf to parse the ANSI color codes that we're generating with fd
-    # --scheme=path optimizes for path-based input
-    # --with-nth allows us to use the custom sorting mechanism
-    FZF_DEFAULT_COMMAND="sh ${script_dirpath}/list-files.sh ${1:-}" fzf \
-        -m \
-        --ansi \
-        --bind='change:top' \
-        --scheme=path \
-        --preview="sh ${script_dirpath}/preview.sh {}"
-    if [ "${?}" -ne 0 ]; then
-        return
-    fi
-)
+done <<< "${fzf_output}"
 
 dirs=()
 text_files=()


### PR DESCRIPTION
## Summary
Fixed a bash syntax error that was causing cmdk to fail with "bad substitution: no closing ')'" error.

## Root Cause
The original code used process substitution `< <(...)` with conditional logic (`if`/`return`) inside it. This creates a subshell where `return` statements don't work properly and can cause syntax errors in different bash versions.

## Solution
- Refactored to use command substitution `$()` to capture fzf output
- Moved error checking outside the substitution
- Use here-string `<<<` to process the captured output
- Changed `return` to `exit 1` for proper subprocess handling

## Testing
- ✅ Tested on macOS with zsh calling bash script
- ✅ Should be compatible with Linux bash and fish (via wrapper)
- ✅ Uses standard bash features for better portability

## Changes
- `cmdk-core.sh`: Restructured fzf execution and output processing

Fixes the "bad substitution" error that prevented cmdk from running.